### PR TITLE
SHOR-144: Fix command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note that this theme and Shoreditch are designed to theme the CiviCRM administra
     # Download ad enable the theme, then set is as the CiviCRM admin theme
     git clone https://github.com/compucorp/shoreditch-companion-d7-theme.git
     drush en -y shoreditch_companion_d7_theme
-    drush vset civicrmtheme_theme_admin seven
+    drush vset civicrmtheme_theme_admin shoreditch_companion_d7_theme
 
     # Clear the civi cache
     drush cc civicrm


### PR DESCRIPTION
The `drush vset civicrmtheme_theme_admin` command in the README was referencing the Seven theme instead of the companion theme